### PR TITLE
build(frontend): fix Tailwind/PostCSS root cause (use config file only)

### DIFF
--- a/web/frontend/postcss.config.cjs
+++ b/web/frontend/postcss.config.cjs
@@ -1,4 +1,4 @@
-/** Single source of truth: Tailwind v4 PostCSS plugin */
+/** Tailwind v4 with the official PostCSS plugin (single source of truth) */
 module.exports = {
   plugins: {
     '@tailwindcss/postcss': {},


### PR DESCRIPTION
Delete web/frontend/package.json .postcss so Vite uses **web/frontend/postcss.config.cjs** with **@tailwindcss/postcss**. Refresh lockfile.