### PR TITLE
ci(pages): deploy web/frontend to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,62 @@
+name: Deploy frontend to GitHub Pages
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      HUSKY: "0"
+      npm_config_ignore_scripts: "true"
+      NPM_CONFIG_FUND: "false"
+      NPM_CONFIG_AUDIT: "false"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: web/frontend/package-lock.json
+
+      - name: Install deps
+        run: |
+          if [ -f web/frontend/package-lock.json ]; then
+            npm --prefix web/frontend ci
+          else
+            npm --prefix web/frontend install
+          fi
+
+      - name: Build (Vite) with repo base
+        run: |
+          REPO="$(basename "$GITHUB_REPOSITORY")"
+          npm --prefix web/frontend run build -- --base="/$REPO/"
+
+      - name: Add SPA 404 fallback (for client routing)
+        run: |
+          cp web/frontend/dist/index.html web/frontend/dist/404.html || true
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: web/frontend/dist
+
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Builds **web/frontend** with Vite (repo base), adds SPA 404 fallback, and deploys to GitHub Pages on pushes to **main**.