### PR TITLE
fix: align ShopiFixer outreach branding

### DIFF
--- a/staffordos/leads/outreach.js
+++ b/staffordos/leads/outreach.js
@@ -214,7 +214,7 @@ function commandQueue(domain) {
     console.error(`No contact email found for ${entry.domain}`);
     process.exit(1);
   }
-  const template = templates[entry.message_type] || templates.abando_audit_invite;
+  const template = templates[entry.message_type] || templates.shopifixer_audit_invite || templates.abando_audit_invite;
   const rendered = renderTemplate(template, entry);
   entry.subject = rendered.subject;
   entry.body = rendered.body;
@@ -256,7 +256,7 @@ function commandNote(domain, noteText) {
 function commandRender(domain) {
   const { queue, templates } = loadState();
   const entry = requireEntry(queue, domain);
-  const template = templates[entry.message_type] || templates.abando_audit_invite;
+  const template = templates[entry.message_type] || templates.shopifixer_audit_invite || templates.abando_audit_invite;
   const rendered = renderTemplate(template, entry);
   console.log(`Domain: ${entry.domain}`);
   console.log(`Email: ${entry.email || "not found"}`);

--- a/staffordos/leads/outreach_templates.json
+++ b/staffordos/leads/outreach_templates.json
@@ -6,5 +6,9 @@
   "abando_followup": {
     "subject": "Quick follow-up on checkout recovery",
     "body": "Following up in case this is useful.\n\nAudit:\n{{audit_link}}\n\nLive recovery flow:\n{{experience_link}}"
+  },
+  "shopifixer_audit_invite": {
+    "subject": "Quick ShopiFixer audit for {{domain}}",
+    "body": "Hi — I noticed {{domain}} may be leaving checkout revenue on the table.\n\nI built ShopiFixer through Stafford Media Consulting to surface checkout leaks and point merchants toward the fastest recovery opportunities.\n\nHere is the audit link:\n{{audit_link}}\n\nIf helpful, I can send over the quick findings."
   }
 }


### PR DESCRIPTION
Adds ShopiFixer outreach template and keeps legacy Abando templates intact. No historical JSON rewrite, no send automation.