### PR TITLE
infra: add canonical lead lifecycle registry

### DIFF
--- a/staffordos/agents/agent_registry_v1.json
+++ b/staffordos/agents/agent_registry_v1.json
@@ -677,6 +677,50 @@
         "enabled": false,
         "strategy": "manual_review_first"
       }
+    },
+    {
+      "id": "lead_registry_sync_agent_v1",
+      "version": "v1",
+      "department": "revenue",
+      "purpose": "Sync existing StaffordOS lead queues into canonical lead lifecycle registry.",
+      "entrypoint": "staffordos/leads/lead_registry_sync_agent_v1.mjs",
+      "reads_from": [
+        "staffordos/leads/outreach_queue.json",
+        "staffordos/leads/contact_research_queue.json",
+        "staffordos/leads/approval_queue_v1.json",
+        "staffordos/leads/send_ledger_v1.json",
+        "staffordos/leads/reply_interpretation_v1.json"
+      ],
+      "writes_to": [
+        "staffordos/leads/lead_registry_v1.json",
+        "staffordos/leads/lead_events_v1.json",
+        "staffordos/leads/lead_registry_sync_log_v1.json"
+      ],
+      "allowed_actions": [
+        "read_truth",
+        "write_truth",
+        "write_log"
+      ],
+      "forbidden_actions": [
+        "send_email",
+        "approve_message",
+        "modify_product_boundary_without_approval",
+        "write_outside_declared_scope"
+      ],
+      "requires_approval": false,
+      "risk_level": "medium",
+      "verification_command": "node staffordos/agents/run_agent_v1.mjs lead_registry_sync_agent_v1",
+      "status": "registered",
+      "constraints": [
+        "no_rebuild",
+        "canonical_lifecycle_layer_only",
+        "no_send",
+        "no_product_surface_patch"
+      ],
+      "auto_repair": {
+        "enabled": false,
+        "strategy": "manual_review_first"
+      }
     }
   ]
 }

--- a/staffordos/leads/lead_events_v1.json
+++ b/staffordos/leads/lead_events_v1.json
@@ -1,0 +1,68 @@
+{
+  "version": "lead_events_v1",
+  "items": [
+    {
+      "id": "event_lead_fitgearpro_myshopify_com_1777300860253",
+      "lead_id": "lead_fitgearpro_myshopify_com",
+      "domain": "fitgearpro.myshopify.com",
+      "event_type": "lead_registered",
+      "product_intent": "shopifixer",
+      "source": "lead_registry_sync_agent_v1",
+      "created_at": "2026-04-27T14:41:00.252Z"
+    },
+    {
+      "id": "event_lead_homegoodsco_myshopify_com_1777300860253",
+      "lead_id": "lead_homegoodsco_myshopify_com",
+      "domain": "homegoodsco.myshopify.com",
+      "event_type": "lead_registered",
+      "product_intent": "shopifixer",
+      "source": "lead_registry_sync_agent_v1",
+      "created_at": "2026-04-27T14:41:00.253Z"
+    },
+    {
+      "id": "event_lead_luxbath_myshopify_com_1777300860253",
+      "lead_id": "lead_luxbath_myshopify_com",
+      "domain": "luxbath.myshopify.com",
+      "event_type": "lead_registered",
+      "product_intent": "shopifixer",
+      "source": "lead_registry_sync_agent_v1",
+      "created_at": "2026-04-27T14:41:00.253Z"
+    },
+    {
+      "id": "event_lead_modernpets_myshopify_com_1777300860253",
+      "lead_id": "lead_modernpets_myshopify_com",
+      "domain": "modernpets.myshopify.com",
+      "event_type": "lead_registered",
+      "product_intent": "shopifixer",
+      "source": "lead_registry_sync_agent_v1",
+      "created_at": "2026-04-27T14:41:00.253Z"
+    },
+    {
+      "id": "event_lead_store1_myshopify_com_1777300860253",
+      "lead_id": "lead_store1_myshopify_com",
+      "domain": "store1.myshopify.com",
+      "event_type": "lead_registered",
+      "product_intent": "shopifixer",
+      "source": "lead_registry_sync_agent_v1",
+      "created_at": "2026-04-27T14:41:00.253Z"
+    },
+    {
+      "id": "event_lead_store2_com_1777300860253",
+      "lead_id": "lead_store2_com",
+      "domain": "store2.com",
+      "event_type": "lead_registered",
+      "product_intent": "shopifixer",
+      "source": "lead_registry_sync_agent_v1",
+      "created_at": "2026-04-27T14:41:00.253Z"
+    },
+    {
+      "id": "event_lead_urbankitchen_myshopify_com_1777300860253",
+      "lead_id": "lead_urbankitchen_myshopify_com",
+      "domain": "urbankitchen.myshopify.com",
+      "event_type": "lead_registered",
+      "product_intent": "shopifixer",
+      "source": "lead_registry_sync_agent_v1",
+      "created_at": "2026-04-27T14:41:00.253Z"
+    }
+  ]
+}

--- a/staffordos/leads/lead_registry_sync_agent_v1.mjs
+++ b/staffordos/leads/lead_registry_sync_agent_v1.mjs
@@ -1,0 +1,226 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+
+const OUTREACH = "staffordos/leads/outreach_queue.json";
+const CONTACT_RESEARCH = "staffordos/leads/contact_research_queue.json";
+const APPROVAL_QUEUE = "staffordos/leads/approval_queue_v1.json";
+const SEND_LEDGER = "staffordos/leads/send_ledger_v1.json";
+const REPLY_INTERPRETATION = "staffordos/leads/reply_interpretation_v1.json";
+const REGISTRY = "staffordos/leads/lead_registry_v1.json";
+const EVENTS = "staffordos/leads/lead_events_v1.json";
+const ROUTING_POLICY = "staffordos/leads/lead_routing_policy_v1.json";
+const LOG = "staffordos/leads/lead_registry_sync_log_v1.json";
+
+function readJson(path, fallback) {
+  if (!existsSync(path)) return fallback;
+  try { return JSON.parse(readFileSync(path, "utf8")); } catch { return fallback; }
+}
+
+function writeJson(path, value) {
+  writeFileSync(path, JSON.stringify(value, null, 2) + "\n");
+}
+
+function normalizeDomain(value = "") {
+  return String(value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/^https?:\/\//, "")
+    .replace(/^www\./, "")
+    .split("/")[0]
+    .split("?")[0]
+    .split("#")[0];
+}
+
+function leadId(domain) {
+  return `lead_${normalizeDomain(domain).replace(/[^a-z0-9]/gi, "_")}`;
+}
+
+function inferProductIntent(item = {}) {
+  const haystack = [
+    item.message_type,
+    item.product,
+    item.notes,
+    item.source_intent,
+    item.product_surface,
+    item.domain
+  ].map((value) => String(value || "").toLowerCase()).join(" ");
+
+  for (const rule of routingPolicy.intent_rules || []) {
+    const matches = Array.isArray(rule.match_any) ? rule.match_any : [];
+    if (matches.some((keyword) => haystack.includes(String(keyword).toLowerCase()))) {
+      return rule.product_intent || routingPolicy.default_product_intent || "shopifixer";
+    }
+  }
+
+  return routingPolicy.default_product_intent || "shopifixer";
+}
+
+function routingFor(intent) {
+  if (intent === "abando") {
+    return {
+      primary_offer: "abando_recovery",
+      secondary_offer: "staffordmedia_services",
+      do_not_cross_sell_until: "qualified"
+    };
+  }
+
+  return {
+    primary_offer: "shopifixer_audit",
+    secondary_offer: "abando_recovery",
+    do_not_cross_sell_until: "qualified"
+  };
+}
+
+function currentStage({ outreachItem, contactItem, approvals, ledgerItems, replies }) {
+  if (replies.length > 0) return "engaged";
+  if (ledgerItems.some(x => x.status === "sent")) return "sent";
+  if (ledgerItems.some(x => x.status === "dry_run_ready")) return "dry_run_ready";
+  if (ledgerItems.length > 0) return "ledgered";
+  if (approvals.some(x => x.status === "approved")) return "approved";
+  if (approvals.some(x => x.status === "pending_review")) return "pending_approval";
+  if (outreachItem?.subject && outreachItem?.body) return "message_ready";
+  if (!outreachItem?.email && !contactItem?.contact_email) return "contact_needed";
+  return "cold";
+}
+
+function bottleneckFor(stage) {
+  const map = {
+    cold: ["routing", "Move lead into contact or message workflow."],
+    contact_needed: ["contact", "Find or add valid contact email."],
+    message_ready: ["approval", "Validate and move message to approval queue."],
+    pending_approval: ["approval", "Review, approve, reject, or hold."],
+    approved: ["send_ledger", "Move approved item into send ledger."],
+    ledgered: ["send_execution", "Run dry-run send execution."],
+    dry_run_ready: ["live_send_locked", "Keep blocked until explicit live-send unlock."],
+    sent: ["reply", "Watch for reply or follow-up window."],
+    engaged: ["qualification", "Qualify intent and route next offer."],
+    qualified: ["close", "Move to service/product close path."],
+    customer: ["success", "Track fulfilled revenue."],
+    stopped: ["stopped", "No next action."]
+  };
+  const [current_bottleneck, next_action] = map[stage] || ["unknown", "Inspect lead state."];
+  return { current_bottleneck, next_action };
+}
+
+const outreach = readJson(OUTREACH, []);
+const contactResearch = readJson(CONTACT_RESEARCH, []);
+const approvalDoc = readJson(APPROVAL_QUEUE, { version: "approval_queue_v1", items: [] });
+const approvals = Array.isArray(approvalDoc.items) ? approvalDoc.items : [];
+const ledgerDoc = readJson(SEND_LEDGER, { version: "send_ledger_v1", items: [] });
+const ledger = Array.isArray(ledgerDoc.items) ? ledgerDoc.items : [];
+const replyDoc = readJson(REPLY_INTERPRETATION, { version: "reply_interpretation_v1", items: [] });
+const replies = Array.isArray(replyDoc.items) ? replyDoc.items : [];
+
+const routingPolicy = readJson(ROUTING_POLICY, {
+  default_product_intent: "shopifixer",
+  products: {},
+  intent_rules: []
+});
+
+const registry = readJson(REGISTRY, { version: "lead_registry_v1", items: [] });
+registry.version = "lead_registry_v1";
+registry.items = Array.isArray(registry.items) ? registry.items : [];
+
+const events = readJson(EVENTS, { version: "lead_events_v1", items: [] });
+events.version = "lead_events_v1";
+events.items = Array.isArray(events.items) ? events.items : [];
+
+const byDomain = new Map(registry.items.map(item => [normalizeDomain(item.domain), item]));
+
+const domains = new Set([
+  ...outreach.map(x => normalizeDomain(x.domain)),
+  ...contactResearch.map(x => normalizeDomain(x.domain)),
+  ...approvals.map(x => normalizeDomain(x.domain)),
+  ...ledger.map(x => normalizeDomain(x.domain)),
+  ...replies.map(x => normalizeDomain(x.domain))
+].filter(Boolean));
+
+let created = 0;
+let updated = 0;
+
+for (const domain of domains) {
+  const outreachItem = outreach.find(x => normalizeDomain(x.domain) === domain) || {};
+  const contactItem = contactResearch.find(x => normalizeDomain(x.domain) === domain) || {};
+  const approvalItems = approvals.filter(x => normalizeDomain(x.domain) === domain);
+  const ledgerItems = ledger.filter(x => normalizeDomain(x.domain) === domain);
+  const replyItems = replies.filter(x => normalizeDomain(x.domain) === domain);
+
+  const existing = byDomain.get(domain) || null;
+  const intent = inferProductIntent(outreachItem);
+  const stage = currentStage({ outreachItem, contactItem, approvals: approvalItems, ledgerItems, replies: replyItems });
+  const status = bottleneckFor(stage);
+  const now = new Date().toISOString();
+
+  const next = {
+    lead_id: existing?.lead_id || leadId(domain),
+    domain,
+    source: outreachItem.source || contactItem.source || "staffordos",
+    lead_state: stage,
+    product_intent: existing?.product_intent || intent,
+    product_surface: intent === "abando" ? "abando_marketing" : "staffordmedia_shopifixer",
+    contact: {
+      email: outreachItem.email || contactItem.contact_email || existing?.contact?.email || "",
+      name: contactItem.contact_name || existing?.contact?.name || "",
+      role: contactItem.contact_role || existing?.contact?.role || "",
+      confidence: contactItem.contact_status || existing?.contact?.confidence || "none"
+    },
+    engagement: {
+      audit_viewed: Boolean(existing?.engagement?.audit_viewed),
+      experience_viewed: Boolean(existing?.engagement?.experience_viewed),
+      replied: replyItems.length > 0 || Boolean(outreachItem.replied),
+      approved_for_send: approvalItems.some(x => x.status === "approved"),
+      dry_run_ready: ledgerItems.some(x => x.status === "dry_run_ready"),
+      sent: ledgerItems.some(x => x.status === "sent") || Boolean(outreachItem.sent)
+    },
+    routing: routingFor(intent),
+    status: {
+      current_stage: stage,
+      ...status
+    },
+    refs: {
+      outreach_queue: Boolean(outreachItem.domain),
+      approval_queue_ids: approvalItems.map(x => x.id).filter(Boolean),
+      send_ledger_ids: ledgerItems.map(x => x.id).filter(Boolean),
+      reply_ids: replyItems.map(x => x.id).filter(Boolean)
+    },
+    created_at: existing?.created_at || now,
+    updated_at: now
+  };
+
+  byDomain.set(domain, next);
+
+  if (existing) updated += 1;
+  else {
+    created += 1;
+    events.items.push({
+      id: `event_${next.lead_id}_${Date.now()}`,
+      lead_id: next.lead_id,
+      domain,
+      event_type: "lead_registered",
+      product_intent: next.product_intent,
+      source: "lead_registry_sync_agent_v1",
+      created_at: now
+    });
+  }
+}
+
+registry.items = Array.from(byDomain.values()).sort((a, b) => a.domain.localeCompare(b.domain));
+writeJson(REGISTRY, registry);
+writeJson(EVENTS, events);
+
+const log = readJson(LOG, []);
+log.push({
+  agent: "lead_registry_sync_agent_v1",
+  created,
+  updated,
+  total: registry.items.length,
+  at: new Date().toISOString()
+});
+writeJson(LOG, log);
+
+console.log(JSON.stringify({
+  ok: true,
+  agent: "lead_registry_sync_agent_v1",
+  created,
+  updated,
+  total: registry.items.length
+}, null, 2));

--- a/staffordos/leads/lead_registry_v1.json
+++ b/staffordos/leads/lead_registry_v1.json
@@ -1,0 +1,285 @@
+{
+  "version": "lead_registry_v1",
+  "items": [
+    {
+      "lead_id": "lead_fitgearpro_myshopify_com",
+      "domain": "fitgearpro.myshopify.com",
+      "source": "staffordos",
+      "lead_state": "contact_needed",
+      "product_intent": "shopifixer",
+      "product_surface": "staffordmedia_shopifixer",
+      "contact": {
+        "email": "",
+        "name": "",
+        "role": "",
+        "confidence": "no_contact_found"
+      },
+      "engagement": {
+        "audit_viewed": false,
+        "experience_viewed": false,
+        "replied": false,
+        "approved_for_send": false,
+        "dry_run_ready": false,
+        "sent": false
+      },
+      "routing": {
+        "primary_offer": "shopifixer_audit",
+        "secondary_offer": "abando_recovery",
+        "do_not_cross_sell_until": "qualified"
+      },
+      "status": {
+        "current_stage": "contact_needed",
+        "current_bottleneck": "contact",
+        "next_action": "Find or add valid contact email."
+      },
+      "refs": {
+        "outreach_queue": true,
+        "approval_queue_ids": [],
+        "send_ledger_ids": [],
+        "reply_ids": []
+      },
+      "created_at": "2026-04-27T14:41:00.252Z",
+      "updated_at": "2026-04-27T14:41:00.252Z"
+    },
+    {
+      "lead_id": "lead_homegoodsco_myshopify_com",
+      "domain": "homegoodsco.myshopify.com",
+      "source": "staffordos",
+      "lead_state": "contact_needed",
+      "product_intent": "shopifixer",
+      "product_surface": "staffordmedia_shopifixer",
+      "contact": {
+        "email": "",
+        "name": "",
+        "role": "",
+        "confidence": "no_contact_found"
+      },
+      "engagement": {
+        "audit_viewed": false,
+        "experience_viewed": false,
+        "replied": false,
+        "approved_for_send": false,
+        "dry_run_ready": false,
+        "sent": false
+      },
+      "routing": {
+        "primary_offer": "shopifixer_audit",
+        "secondary_offer": "abando_recovery",
+        "do_not_cross_sell_until": "qualified"
+      },
+      "status": {
+        "current_stage": "contact_needed",
+        "current_bottleneck": "contact",
+        "next_action": "Find or add valid contact email."
+      },
+      "refs": {
+        "outreach_queue": true,
+        "approval_queue_ids": [],
+        "send_ledger_ids": [],
+        "reply_ids": []
+      },
+      "created_at": "2026-04-27T14:41:00.253Z",
+      "updated_at": "2026-04-27T14:41:00.253Z"
+    },
+    {
+      "lead_id": "lead_luxbath_myshopify_com",
+      "domain": "luxbath.myshopify.com",
+      "source": "staffordos",
+      "lead_state": "contact_needed",
+      "product_intent": "shopifixer",
+      "product_surface": "staffordmedia_shopifixer",
+      "contact": {
+        "email": "",
+        "name": "",
+        "role": "",
+        "confidence": "no_contact_found"
+      },
+      "engagement": {
+        "audit_viewed": false,
+        "experience_viewed": false,
+        "replied": false,
+        "approved_for_send": false,
+        "dry_run_ready": false,
+        "sent": false
+      },
+      "routing": {
+        "primary_offer": "shopifixer_audit",
+        "secondary_offer": "abando_recovery",
+        "do_not_cross_sell_until": "qualified"
+      },
+      "status": {
+        "current_stage": "contact_needed",
+        "current_bottleneck": "contact",
+        "next_action": "Find or add valid contact email."
+      },
+      "refs": {
+        "outreach_queue": true,
+        "approval_queue_ids": [],
+        "send_ledger_ids": [],
+        "reply_ids": []
+      },
+      "created_at": "2026-04-27T14:41:00.253Z",
+      "updated_at": "2026-04-27T14:41:00.253Z"
+    },
+    {
+      "lead_id": "lead_modernpets_myshopify_com",
+      "domain": "modernpets.myshopify.com",
+      "source": "staffordos",
+      "lead_state": "contact_needed",
+      "product_intent": "shopifixer",
+      "product_surface": "staffordmedia_shopifixer",
+      "contact": {
+        "email": "",
+        "name": "",
+        "role": "",
+        "confidence": "no_contact_found"
+      },
+      "engagement": {
+        "audit_viewed": false,
+        "experience_viewed": false,
+        "replied": false,
+        "approved_for_send": false,
+        "dry_run_ready": false,
+        "sent": false
+      },
+      "routing": {
+        "primary_offer": "shopifixer_audit",
+        "secondary_offer": "abando_recovery",
+        "do_not_cross_sell_until": "qualified"
+      },
+      "status": {
+        "current_stage": "contact_needed",
+        "current_bottleneck": "contact",
+        "next_action": "Find or add valid contact email."
+      },
+      "refs": {
+        "outreach_queue": true,
+        "approval_queue_ids": [],
+        "send_ledger_ids": [],
+        "reply_ids": []
+      },
+      "created_at": "2026-04-27T14:41:00.253Z",
+      "updated_at": "2026-04-27T14:41:00.253Z"
+    },
+    {
+      "lead_id": "lead_store1_myshopify_com",
+      "domain": "store1.myshopify.com",
+      "source": "staffordos",
+      "lead_state": "cold",
+      "product_intent": "shopifixer",
+      "product_surface": "staffordmedia_shopifixer",
+      "contact": {
+        "email": "owner@store1.com",
+        "name": "Jane Smith",
+        "role": "Founder",
+        "confidence": "contact_page_ready"
+      },
+      "engagement": {
+        "audit_viewed": false,
+        "experience_viewed": false,
+        "replied": false,
+        "approved_for_send": false,
+        "dry_run_ready": false,
+        "sent": false
+      },
+      "routing": {
+        "primary_offer": "shopifixer_audit",
+        "secondary_offer": "abando_recovery",
+        "do_not_cross_sell_until": "qualified"
+      },
+      "status": {
+        "current_stage": "cold",
+        "current_bottleneck": "routing",
+        "next_action": "Move lead into contact or message workflow."
+      },
+      "refs": {
+        "outreach_queue": true,
+        "approval_queue_ids": [],
+        "send_ledger_ids": [],
+        "reply_ids": []
+      },
+      "created_at": "2026-04-27T14:41:00.253Z",
+      "updated_at": "2026-04-27T14:41:00.253Z"
+    },
+    {
+      "lead_id": "lead_store2_com",
+      "domain": "store2.com",
+      "source": "staffordos",
+      "lead_state": "contact_needed",
+      "product_intent": "shopifixer",
+      "product_surface": "staffordmedia_shopifixer",
+      "contact": {
+        "email": "",
+        "name": "",
+        "role": "",
+        "confidence": "no_contact_found"
+      },
+      "engagement": {
+        "audit_viewed": false,
+        "experience_viewed": false,
+        "replied": false,
+        "approved_for_send": false,
+        "dry_run_ready": false,
+        "sent": false
+      },
+      "routing": {
+        "primary_offer": "shopifixer_audit",
+        "secondary_offer": "abando_recovery",
+        "do_not_cross_sell_until": "qualified"
+      },
+      "status": {
+        "current_stage": "contact_needed",
+        "current_bottleneck": "contact",
+        "next_action": "Find or add valid contact email."
+      },
+      "refs": {
+        "outreach_queue": true,
+        "approval_queue_ids": [],
+        "send_ledger_ids": [],
+        "reply_ids": []
+      },
+      "created_at": "2026-04-27T14:41:00.253Z",
+      "updated_at": "2026-04-27T14:41:00.253Z"
+    },
+    {
+      "lead_id": "lead_urbankitchen_myshopify_com",
+      "domain": "urbankitchen.myshopify.com",
+      "source": "staffordos",
+      "lead_state": "contact_needed",
+      "product_intent": "shopifixer",
+      "product_surface": "staffordmedia_shopifixer",
+      "contact": {
+        "email": "",
+        "name": "",
+        "role": "",
+        "confidence": "no_contact_found"
+      },
+      "engagement": {
+        "audit_viewed": false,
+        "experience_viewed": false,
+        "replied": false,
+        "approved_for_send": false,
+        "dry_run_ready": false,
+        "sent": false
+      },
+      "routing": {
+        "primary_offer": "shopifixer_audit",
+        "secondary_offer": "abando_recovery",
+        "do_not_cross_sell_until": "qualified"
+      },
+      "status": {
+        "current_stage": "contact_needed",
+        "current_bottleneck": "contact",
+        "next_action": "Find or add valid contact email."
+      },
+      "refs": {
+        "outreach_queue": true,
+        "approval_queue_ids": [],
+        "send_ledger_ids": [],
+        "reply_ids": []
+      },
+      "created_at": "2026-04-27T14:41:00.253Z",
+      "updated_at": "2026-04-27T14:41:00.253Z"
+    }
+  ]
+}

--- a/staffordos/leads/lead_routing_policy_v1.json
+++ b/staffordos/leads/lead_routing_policy_v1.json
@@ -1,0 +1,58 @@
+{
+  "version": "lead_routing_policy_v1",
+  "purpose": "Canonical product routing policy for StaffordOS leads. Prevents overlap and cannibalization across ShopiFixer, Abando, and Stafford Media.",
+  "default_product_intent": "shopifixer",
+  "products": {
+    "shopifixer": {
+      "product_surface": "staffordmedia_shopifixer",
+      "primary_offer": "shopifixer_audit",
+      "secondary_offer": "abando_recovery",
+      "do_not_cross_sell_until": "qualified"
+    },
+    "abando": {
+      "product_surface": "abando_marketing",
+      "primary_offer": "abando_recovery",
+      "secondary_offer": "staffordmedia_services",
+      "do_not_cross_sell_until": "recovery_interest"
+    },
+    "staffordmedia": {
+      "product_surface": "staffordmedia_services",
+      "primary_offer": "automation_consulting",
+      "secondary_offer": "shopifixer_audit",
+      "do_not_cross_sell_until": "problem_confirmed"
+    }
+  },
+  "intent_rules": [
+    {
+      "match_any": [
+        "shopifixer",
+        "shopifix",
+        "fix audit",
+        "shopify fix",
+        "checkout leak",
+        "staffordmedia_shopifixer"
+      ],
+      "product_intent": "shopifixer"
+    },
+    {
+      "match_any": [
+        "abando_recovery",
+        "recovery engine",
+        "see recovery",
+        "checkout recovery",
+        "abando_checkout_install"
+      ],
+      "product_intent": "abando"
+    },
+    {
+      "match_any": [
+        "stafford media",
+        "staffordmedia",
+        "automation consulting",
+        "consulting",
+        "agency"
+      ],
+      "product_intent": "staffordmedia"
+    }
+  ]
+}

--- a/staffordos/leads/lead_state_machine_v1.json
+++ b/staffordos/leads/lead_state_machine_v1.json
@@ -1,0 +1,51 @@
+{
+  "version": "lead_state_machine_v1",
+  "states": [
+    "cold",
+    "contact_needed",
+    "message_ready",
+    "pending_approval",
+    "approved",
+    "ledgered",
+    "dry_run_ready",
+    "sent",
+    "engaged",
+    "qualified",
+    "customer",
+    "stopped"
+  ],
+  "transitions": {
+    "cold": ["contact_needed", "message_ready"],
+    "contact_needed": ["message_ready", "stopped"],
+    "message_ready": ["pending_approval"],
+    "pending_approval": ["approved", "stopped"],
+    "approved": ["ledgered"],
+    "ledgered": ["dry_run_ready", "sent"],
+    "dry_run_ready": ["sent", "engaged"],
+    "sent": ["engaged", "stopped"],
+    "engaged": ["qualified", "stopped"],
+    "qualified": ["customer", "stopped"],
+    "customer": [],
+    "stopped": []
+  },
+  "routing_rules": {
+    "shopifixer": {
+      "primary_surface": "staffordmedia_shopifixer",
+      "primary_offer": "shopifixer_audit",
+      "secondary_offer": "abando_recovery",
+      "cross_sell_rule": "Only introduce Abando after audit interest, reply, or qualified intent."
+    },
+    "abando": {
+      "primary_surface": "abando_marketing",
+      "primary_offer": "abando_recovery",
+      "secondary_offer": "staffordmedia_services",
+      "cross_sell_rule": "Do not dilute Abando with generic agency messaging."
+    },
+    "staffordmedia": {
+      "primary_surface": "staffordmedia_home",
+      "primary_offer": "diagnostic_service",
+      "secondary_offer": "shopifixer_or_abando",
+      "cross_sell_rule": "Route based on merchant pain: audit/fix vs recovery automation."
+    }
+  }
+}


### PR DESCRIPTION
Adds canonical lead registry, event log, state machine, routing policy, and sync agent to prevent product overlap across ShopiFixer, Abando, and Stafford Media. No rebuild, no send automation, no surface changes.